### PR TITLE
[backport 5.3.1] fix(canvas): add group index when unrolling tasks

### DIFF
--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -36,7 +36,7 @@ jobs:
               os: "windows-latest"
             - python-version: 'pypy-3.10'
               os: "windows-latest"
-            
+
     steps:
     - name: Install apt packages
       if: startsWith(matrix.os, 'ubuntu-')
@@ -58,12 +58,6 @@ jobs:
       timeout-minutes: 30
       run: |
         tox --verbose --verbose
-
-    - uses: codecov/codecov-action@v3
-      with:
-        flags: unittests # optional
-        fail_ci_if_error: true # optional (default = false)
-        verbose: true # optional (default = false)
 
   Integration:
       needs:

--- a/.github/workflows/python-package.yml
+++ b/.github/workflows/python-package.yml
@@ -12,7 +12,6 @@ on:
         - '.github/workflows/python-package.yml'
         - '**.toml'
   pull_request:
-    branches: [ 'main']
     paths:
         - '**.py'
         - '**.txt'

--- a/celery/canvas.py
+++ b/celery/canvas.py
@@ -1704,7 +1704,7 @@ class group(Signature):
             generator: A generator for the unrolled group tasks.
                 The generator yields tuples of the form ``(task, AsyncResult, group_id)``.
         """
-        for task in tasks:
+        for index, task in enumerate(tasks):
             if isinstance(task, CallableSignature):
                 # local sigs are always of type Signature, and we
                 # clone them to make sure we don't modify the originals.
@@ -1721,7 +1721,7 @@ class group(Signature):
             else:
                 if partial_args and not task.immutable:
                     task.args = tuple(partial_args) + tuple(task.args)
-                yield task, task.freeze(group_id=group_id, root_id=root_id), group_id
+                yield task, task.freeze(group_id=group_id, root_id=root_id, group_index=index), group_id
 
     def _apply_tasks(self, tasks, producer=None, app=None, p=None,
                      add_to_parent=None, chord=None,

--- a/t/integration/test_canvas.py
+++ b/t/integration/test_canvas.py
@@ -1520,6 +1520,18 @@ class test_chord:
         result = c()
         assert result.get(timeout=TIMEOUT) == 4
 
+    def test_chord_order(self, manager):
+        try:
+            manager.app.backend.ensure_chords_allowed()
+        except NotImplementedError as e:
+            raise pytest.skip(e.args[0])
+
+        inputs = [i for i in range(10)]
+
+        c = chord((identity.si(i) for i in inputs), identity.s())
+        result = c()
+        assert result.get() == inputs
+
     @pytest.mark.xfail(reason="async_results aren't performed in async way")
     def test_redis_subscribed_channels_leak(self, manager):
         if not manager.app.conf.result_backend.startswith('redis'):


### PR DESCRIPTION
Backport of https://github.com/BackMarket-oss/celery/commit/097ef3095b7a42fcb83cc2c88c697469df2ae94d to 5.3.1.